### PR TITLE
set invert color for img in dark mode

### DIFF
--- a/assets/css/classes.sass
+++ b/assets/css/classes.sass
@@ -8,6 +8,8 @@
 .dark
   background: #282828
   color: #ffffff
+.dark img
+  filter: invert(100%)
 
 .icon
   margin: 0 1em


### PR DESCRIPTION
fixed that transparent SVG image can't see in dark mode