### PR TITLE
Prevent 404 in GitHub Pages

### DIFF
--- a/_posts/2017-05-13-pijul.md
+++ b/_posts/2017-05-13-pijul.md
@@ -6,7 +6,7 @@ title: "Part 2: Merging, patches, and pijul"
 In the [last post]({{ site.baseurl }}{% post_url 2017-05-08-merging %}),
 I talked about a mathematical
 framework for a version control system (VCS) without merge conflicts. In this
-post I'll explore [pijul](pijul.com), which is a VCS based on a similar system.
+post I'll explore [pijul](https://pijul.com/), which is a VCS based on a similar system.
 Note that pijul is under heavy development; this post is based on a development
 snapshot (I almost called it a "git" snapshot by mistake), and might be out of
 date by the time you read it.


### PR DESCRIPTION
Without the protocol prefix, it's interpreted as a relative path: https://jneem.github.io/pijul/pijul.com ;-)